### PR TITLE
Bug-Fix for incorrect GET paths for schedule

### DIFF
--- a/source/backend/routes/ScheduleRouter.js
+++ b/source/backend/routes/ScheduleRouter.js
@@ -54,7 +54,7 @@ router.put("/", async (req, res) => {
 router.get("/", async (req, res) => {
 
     // Get restaurant and day from body
-    const { restID, day } = req.body;
+    const { restID, day } = req.query;
 
     // Ensure restaurant exists
     const rest = await Restaurant.findByPk(parseInt(restID));
@@ -90,10 +90,10 @@ router.get("/", async (req, res) => {
 
 
 // GET /restaurant/schedule/weekly
-router.get("/weekly", async (req, res) => {
+router.get("/weekly/:restID", async (req, res) => {
 
     // Get restaurant Id from body
-    const {restID} = req.body;
+    const restID = req.params.restID;
     let schedule = {}
 
     // Ensure restaurant exists

--- a/source/backend/tests/integration/ScheduleIntegration.test.js
+++ b/source/backend/tests/integration/ScheduleIntegration.test.js
@@ -14,33 +14,24 @@ describe("Schedule API", () => {
 
     it("Get restaurant schedule: open", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule")
-        .send({
-            restID: restID,
-            day: "sunday",
-        });
+        .get(`/v1/restaurant/schedule?restID=${restID}&day=sunday`)
+
         expect(res.body.close).toEqual(24.0);
         expect(res.body.currently_open).toBe(true);
     });
 
     it("Get restaurant schedule: closed", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule")
-        .send({
-            restID: restID,
-            day: "monday",
-        });
+        .get(`/v1/restaurant/schedule?restID=${restID}&day=monday`)
+
         expect(res.body.close).toEqual(0.0);
         expect(res.body.currently_open).toBe(false);
     });
 
     it("Get schedule on invalid day", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule")
-        .send({
-            restID: restID,
-            day: "badday",
-        });
+        .get(`/v1/restaurant/schedule?restID=${restID}&day=badday`)
+
         expect(res.status).toBe(400);
     });
 
@@ -80,49 +71,36 @@ describe("Schedule API", () => {
 
     it("Verify new Sunday schedule", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule")
-        .send({
-            restID: restID,
-            day: "sunday",
-        });
+        .get(`/v1/restaurant/schedule?restID=${restID}&day=sunday`)
+
         expect(res.body.close).toEqual(0.0);
     });
 
     it("Verify new Monday schedule", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule")
-        .send({
-            restID: restID,
-            day: "monday",
-        });
+        .get(`/v1/restaurant/schedule?restID=${restID}&day=monday`)
+
         expect(res.body.close).toEqual(20.75);
     });
 
     it("Verify new Wednesday schedule", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule")
-        .send({
-            restID: restID,
-            day: "wednesday",
-        });
+        .get(`/v1/restaurant/schedule?restID=${restID}&day=wednesday`)
+
         expect(res.body.close).toEqual(18.3);
     });
 
     it("Verify invalid restID", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule/weekly")
-        .send({
-            restID: 9999,
-        });
+        .get(`/v1/restaurant/schedule/weekly/${9999}`)
+
         expect(res.status).toBe(404);
     });
 
      it("Verify valid restID", async () => {
         const res = await request(app)
-        .get("/v1/restaurant/schedule/weekly")
-        .send({
-            restID
-        });
+        .get(`/v1/restaurant/schedule/weekly/${restID}`)
+
         expect(res.status).toBe(200);
         const days = Object.keys(await res.body.schedule)
         expect(days.length).toBe(7)


### PR DESCRIPTION
- Fixed GET paths of schedule
  - [x] added query to GET ../schedule?restID=x&day=x
  - [x] added param to GET ../schedule/weekly/restID 


Resolves #102 